### PR TITLE
Split dimacs generation from argument parsing

### DIFF
--- a/kth2dimacs.py
+++ b/kth2dimacs.py
@@ -123,7 +123,7 @@ def pebbling_formula_clauses(kthfile):
 
         target,sources=l.split(':')
         target=int(target.strip())
-        yield [target]+[ -int(i) for i in sources.split() ]
+        yield [ -int(i) for i in sources.split() ]+[target]
 
     yield [-target]
 
@@ -212,7 +212,7 @@ def lift(clauses,lift_method='none',lift_rank=None):
     raise StopClauses(output_variables,output_clauses)
     
 
-def kth2dimacs(input, liftname, liftrank, output, header=True) :
+def kth2dimacs(input, liftname, liftrank, output, header=True, comments=True) :
     # Build the lifting mechanism
 
     # Generate the basic formula
@@ -234,13 +234,15 @@ def kth2dimacs(input, liftname, liftrank, output, header=True) :
             
     except StopClauses as cnfinfo:
 
+        if comments:
+            print("c Pebbling CNF with lifting \'{}\' of rank {}".format(liftname,liftrank),
+                  file=output)
+
         if header:
             # clauses cached in memory
-            print("c Pebbling CNF with lifting \'{}\' of rank {}".format(lift,liftrank),
-                  file=output)
             print("p cnf {} {}".format(cnfinfo.variables,cnfinfo.clauses),
                   file=output)
-            print(output_cache.getvalue(),file=output)
+            output.write(output_cache.getvalue())
 
         else:
             # clauses have been already sent to output

--- a/test.py
+++ b/test.py
@@ -6,6 +6,7 @@ import cnfformula.utils as cnfutils
 
 import cnfgen
 import reshuffle
+import kth2dimacs
 
 import unittest
 import networkx as nx
@@ -253,6 +254,34 @@ class TestSubstitution(TestCNF) :
 
         lift2 = cnfformula.LiftFormula(cnf, 'one', 2)
         self.assertCnfEqual(lift,lift2)
+
+class TestKth2Dimacs(TestCNF) :
+    def identity_test_helper(self, input, liftname, liftrank) :
+        G = cnfgen.readDigraph(input,'kth')
+        input.seek(0)
+        peb = cnfgen.PebblingFormula(G)
+        lift = cnfgen.LiftFormula(peb, liftname, liftrank)
+        reference_output = lift.dimacs(add_header=False, add_comments=False)+"\n"
+        
+        kth2dimacs_output=StringIO.StringIO()
+        kth2dimacs.kth2dimacs(input, liftname, liftrank, kth2dimacs_output, header=True, comments=False)
+        self.assertMultiLineEqual(kth2dimacs_output.getvalue(), reference_output)
+
+    def test_unit_graph(self) :
+        input = StringIO.StringIO("1\n1 :\n")
+        self.identity_test_helper(input, 'none', 0)
+
+    def test_small_line(self) :
+        input = StringIO.StringIO("3\n1 :\n2 : 1\n3 : 2\n")
+        self.identity_test_helper(input, 'none', 0)
+
+    def test_small_pyramid(self) :
+        input = StringIO.StringIO("3\n1 : \n2 : \n3 : 1 2\n")
+        self.identity_test_helper(input, 'none', 0)        
+        
+    def test_substitution(self) :
+        input = StringIO.StringIO("3\n1 : \n2 : \n3 : 1 2\n")
+        self.identity_test_helper(input, 'or', 2)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Would you mind splitting the conversion into another function? It is easier to test this way because I can feed the function StringIO objects instead of files.
