### PR TITLE
Use python2 in virtual env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PROJECT=cnfgen
-PYTHON_BIN = /usr/bin/python
+PYTHON_BIN = python2
 VIRTUALENV = $(HOME)/.virtualenvs/$(PROJECT)-venv
 
 


### PR DESCRIPTION
From [PEP 394] (https://www.python.org/dev/peps/pep-0394/)
> code that needs to invoke the Python interpreter should not specify python, but rather should specify either python2 or python3