### PR TITLE
Semantic tests for PHP

### DIFF
--- a/cnfformula/tests/satisfiable.py
+++ b/cnfformula/tests/satisfiable.py
@@ -1,0 +1,21 @@
+from cnfformula import CNF
+
+# Returns True/False/undefined
+def evaluate_clause(clause, assignment):
+    undef = False
+    for (polarity, variable) in clause:
+        if variable in assignment:
+            if (assignment[variable]==polarity) : return True
+        else:
+            undef = True
+    if (undef) : return None
+    return False
+
+
+# Returns a tuple (satisfied, falsified, undefined)
+def evaluate_cnf(CNF, assignment):
+    return (
+        [c for c in CNF if evaluate_clause(c,assignment) is True],
+        [c for c in CNF if evaluate_clause(c,assignment) is False],
+        [c for c in CNF if evaluate_clause(c,assignment) is None],
+    )

--- a/cnfformula/tests/test_pigeonhole_principle.py
+++ b/cnfformula/tests/test_pigeonhole_principle.py
@@ -6,6 +6,8 @@ from .test_commandline_helper import TestCommandline
 
 import unittest
 import networkx as nx
+from itertools import permutations, product, chain
+from .satisfiable import evaluate_cnf
 
 class TestPigeonholePrinciple(TestCNFBase):
     def test_empty(self):
@@ -108,7 +110,35 @@ class TestPigeonholePrinciple(TestCNFBase):
         -3 -4 0
         """
         self.assertCnfEqualsDimacs(F,dimacs)
-        
+
+    def test_one_pigeon_unmatched(self):
+        pigeons = 6
+        holes = 5
+        F = PigeonholePrinciple(pigeons, holes)
+        for pi in permutations(range(pigeons),holes):
+            assignment = {
+                'p_{{{0},{1}}}'.format(p+1,h+1) : (pi[h]==p)
+                for p,h in product(range(pigeons),range(holes))
+            }
+            satisfied,falsified,undefined = evaluate_cnf(F,assignment)
+            self.assertEquals(len(falsified),1)
+            self.assertEquals(len(undefined),0)
+
+    def test_one_hole_overfull(self):
+        pigeons = 5
+        holes = 4
+        F = PigeonholePrinciple(pigeons, holes)
+        for extra in range(holes):
+            destinations = chain(range(holes),[extra])
+            for pi in permutations(destinations):
+                assignment = {
+                    'p_{{{0},{1}}}'.format(p+1,h+1) : (pi[p]==h)
+                    for p,h in product(range(pigeons),range(holes))
+                }
+                satisfied,falsified,undefined = evaluate_cnf(F,assignment)
+                self.assertEquals(len(falsified),1)
+                self.assertEquals(len(undefined),0)
+
 def complete_bipartite_graph_proper(n,m):
     g = nx.complete_bipartite_graph(n,m)
     values = {k:v for (k,v) in enumerate([0]*n + [1]*m)}


### PR DESCRIPTION
This adds some tests that check whether a given assignment satisfies / falsifies the expected clauses. It seems a good complement to generating the same cnf by hand or with another generator and checking if they are equal. The `evaluate_clause` and `evaluate_cnf` functions are candidates to eventually move into the main API.