### PR TITLE
Tests for Even colouring formulas

### DIFF
--- a/cnfformula/cnfgen.py
+++ b/cnfformula/cnfgen.py
@@ -205,7 +205,11 @@ def command_line_utility(argv=sys.argv):
         random.seed(args.seed)
 
     # Generate the formula
-    cnf=args.subcommand.build_cnf(args)
+    try:
+        cnf = args.subcommand.build_cnf(args)
+    except ValueError as e:
+        print(e, file=sys.stderr)
+        exit(os.EX_DATAERR)
     if args.Transform == 'none':
         tcnf = cnf
     else:

--- a/cnfformula/cnfgen.py
+++ b/cnfformula/cnfgen.py
@@ -209,7 +209,7 @@ def command_line_utility(argv=sys.argv):
         cnf = args.subcommand.build_cnf(args)
     except ValueError as e:
         print(e, file=sys.stderr)
-        exit(os.EX_DATAERR)
+        sys.exit(os.EX_DATAERR)
     if args.Transform == 'none':
         tcnf = cnf
     else:

--- a/cnfformula/tests/__init__.py
+++ b/cnfformula/tests/__init__.py
@@ -41,6 +41,11 @@ class TestCNFBase(unittest.TestCase):
     def assertCnfEquivalentModuloVariables(self, cnf1, cnf2):
         self.assertSetEqual(set(cnf1._clauses), set(cnf2._clauses))
 
+    def assertCnfEquivalentModuloVariableNames(self, cnf1, cnf2):
+        tovars1 = dict(zip(cnf2.variables(), cnf1.variables()))
+        clauses2 = [[(p,tovars1[v]) for p,v in C] for C in cnf2.clauses()]
+        self.assertSetSetEqual(cnf1.clauses(), clauses2)
+
     def assertSAT(self, formula):
         if have_satsolver():
             result, _ = is_satisfiable(formula)

--- a/cnfformula/tests/__init__.py
+++ b/cnfformula/tests/__init__.py
@@ -41,11 +41,6 @@ class TestCNFBase(unittest.TestCase):
     def assertCnfEquivalentModuloVariables(self, cnf1, cnf2):
         self.assertSetEqual(set(cnf1._clauses), set(cnf2._clauses))
 
-    def assertCnfEquivalentModuloVariableNames(self, cnf1, cnf2):
-        tovars1 = dict(zip(cnf2.variables(), cnf1.variables()))
-        clauses2 = [[(p,tovars1[v]) for p,v in C] for C in cnf2.clauses()]
-        self.assertSetSetEqual(cnf1.clauses(), clauses2)
-
     def assertSAT(self, formula):
         if have_satsolver():
             result, _ = is_satisfiable(formula)

--- a/cnfformula/tests/test_evencolouring.py
+++ b/cnfformula/tests/test_evencolouring.py
@@ -1,0 +1,39 @@
+import networkx as nx
+
+from cnfformula import CNF
+from cnfformula import EvenColoringFormula, TseitinFormula
+
+from . import TestCNFBase
+from .test_commandline_helper import TestCommandline
+
+class TestEvenColouring(TestCNFBase):
+    def test_empty(self):
+        G = CNF()
+        graph = nx.Graph()
+        F = EvenColoringFormula(graph)
+        self.assertCnfEqual(F,G)
+
+    def test_odd_degree(self):
+        graph = nx.path_graph(2)
+        with self.assertRaises(ValueError):
+            EvenColoringFormula(graph)
+
+    def test_cycle(self):
+        for n in range(3,8):
+            graph = nx.cycle_graph(n)
+            F = EvenColoringFormula(graph)
+            G = TseitinFormula(graph,[1]*n)
+            self.assertCnfEquivalentModuloVariableNames(F,G)
+
+class TestEvenColouringCommandline(TestCommandline):
+    def test_complete(self):
+        for n in range(3,8,2):
+            parameters = ["ec", "--complete", n]
+            graph = nx.complete_graph(n)
+            F = EvenColoringFormula(graph)
+            self.checkFormula(F, parameters)
+
+    def test_odd_degree(self):
+        for n in range(4,7,2):
+            parameters = ["ec", "--complete", n]
+            self.checkCrash(parameters)

--- a/cnfformula/tests/test_evencolouring.py
+++ b/cnfformula/tests/test_evencolouring.py
@@ -23,7 +23,7 @@ class TestEvenColouring(TestCNFBase):
             graph = nx.cycle_graph(n)
             F = EvenColoringFormula(graph)
             G = TseitinFormula(graph,[1]*n)
-            self.assertCnfEquivalentModuloVariableNames(F,G)
+            self.assertCnfEquivalentModuloVariables(F,G)
 
 class TestEvenColouringCommandline(TestCommandline):
     def test_complete(self):


### PR DESCRIPTION
Add tests for even colouring formulas.

Since only graphs of even degree are accepted, the command line would throw an exception, so I changed the command line code to catch it. I do not see any better place to do this, since the validation is too complex to do during parsing. This also fixes the case when other formulas fail, such as `cnfgen randkcnf 3 4 99999`.