### PR TITLE
Do not reload modules

### DIFF
--- a/cnfformula/cmdline.py
+++ b/cnfformula/cmdline.py
@@ -198,7 +198,10 @@ def find_methods_in_package(package,test, sortkey=None):
     
     for loader, module_name, _ in  pkgutil.walk_packages(package.__path__):
         module_name = package.__name__+"."+module_name
-        module = loader.find_module(module_name).load_module(module_name)
+        if module_name in sys.modules:
+            module = sys.modules[module_name]
+        else:
+            module = loader.find_module(module_name).load_module(module_name)
         for objname in dir(module):
             obj = getattr(module, objname)
             if test(obj):


### PR DESCRIPTION
Looking at https://hg.python.org/cpython/file/2.7/Lib/pkgutil.py, it seems that it calls `imp.load_module()`, which will `reload()` a module if it is already there. And according to https://docs.python.org/2/library/functions.html#reload, previously imported names no longer behave as expected, so they would need to be imported again. I think it is better not to reload modules.