### PR TITLE
Clarify autodetect error

### DIFF
--- a/cnfformula/graphs.py
+++ b/cnfformula/graphs.py
@@ -175,10 +175,10 @@ def _process_graph_io_arguments(iofile,
         try:
             extension = os.path.splitext(iofile.name)[-1][1:]
         except AttributeError:
-            raise ValueError("No file name corresponds to IO stream. Can't guess a file format.")
+            raise ValueError("Cannot guess a file format from an IO stream with no name. Please specify the format manually.")
 
         if extension not in _graphformats[graph_type]:
-            raise ValueError("Cannot guess a file format for {} graphs from \"{}\".".\
+            raise ValueError("Cannot guess a file format for {} graphs from the extension of \"{}\". Please specify the format manually.".\
                              format(graph_type,iofile.name))
         else:
             file_format=extension


### PR DESCRIPTION
Joseph was very confused by the "Cannot guess a file format message": he thought cnfgen would try to read all formats it knows and fail if the contents of the file were unreadable, not if it did not like the extension. I rewrote the message to be more clear.

Question 1: should cnfgen do the first thing, i.e. try to read in all formats, and succeed if exactly one succeeds?
Question 2: if not, should the error direct the user to --graphformat? I did not do that because it is the command line's task, but currently the command line cannot distinguish between errors.