### PR TITLE
OPB

### DIFF
--- a/cnfformula/cnf.py
+++ b/cnfformula/cnf.py
@@ -1080,7 +1080,11 @@ class CNF(object):
         threshold = len(variables)/2
         return cls.equal_to_constraint(variables,threshold)
 
-    class unary_mapping(object):
+    @classmethod
+    def unary_mapping(cls, D, R, **kwargs):
+        return cls._unary_mapping(cls, D, R, **kwargs)
+
+    class _unary_mapping(object):
         """Unary CNF representation of a mapping between two sets."""
         
         Domain = None
@@ -1099,7 +1103,7 @@ class CNF(object):
         def var_name(i,b):
             return "X_{{{0},{1}}}".format(i,b)
 
-        def __init__(self, D, R,**kwargs):
+        def __init__(self, cls, D, R, **kwargs):
             r"""Generator for the clauses of a mapping between to sets
 
             This generates of the constraints on variables :math:`v(i,j)`
@@ -1143,6 +1147,8 @@ class CNF(object):
                 the order of domain and range (default: false)
                 
             """
+            self.cls = cls
+
             self.Domain = list(D)
             self.Range  = list(R)
 
@@ -1230,25 +1236,25 @@ class CNF(object):
             # Completeness axioms
             if self.Complete:
                 for d in self.Domain:
-                    for c in CNF.greater_or_equal_constraint([self.var_name(d,r) for r in self.images(d)], 1):
+                    for c in self.cls.greater_or_equal_constraint([self.var_name(d,r) for r in self.images(d)], 1):
                         yield c
                     
             # Surjectivity axioms
             if self.Surjective:
                 for r in self.Range:
-                    for c in CNF.greater_or_equal_constraint([self.var_name(d,r) for d in self.counterimages(r)], 1):
+                    for c in self.cls.greater_or_equal_constraint([self.var_name(d,r) for d in self.counterimages(r)], 1):
                         yield c
 
             # Injectivity axioms
             if self.Injective:
                 for r in self.Range:
-                    for c in CNF.less_or_equal_constraint([self.var_name(d,r)  for d in self.counterimages(r)],1):
+                    for c in self.cls.less_or_equal_constraint([self.var_name(d,r)  for d in self.counterimages(r)],1):
                         yield c
 
             # Functionality axioms
             if self.Functional:
                 for d in self.Domain:
-                    for c in CNF.less_or_equal_constraint([self.var_name(d,r) for r in self.images(d)],1):
+                    for c in self.cls.less_or_equal_constraint([self.var_name(d,r) for r in self.images(d)],1):
                         yield c
 
             # Mapping is monotone non-decreasing

--- a/cnfformula/cnfgen.py
+++ b/cnfformula/cnfgen.py
@@ -34,6 +34,8 @@ import os
 import sys
 import random
 
+from csp import CSP
+
 # Python 2.6 does not have argparse library
 try:
     import argparse
@@ -70,7 +72,7 @@ def setup_command_line_args(parser):
                         formula to standard output. (default: -)
                         """)
     parser.add_argument('--output-format','-of',
-                        choices=['latex','dimacs'],
+                        choices=['latex','dimacs','opb'],
                         default='dimacs',
                         help="""
                         Output format of the formulas. 'latex' is
@@ -217,6 +219,9 @@ a sequence of transformations.
     # If necessary, init the random generator
     if hasattr(args,'seed') and args.seed:
         random.seed(args.seed)
+
+    # Choose constraint format
+    CSP.set_format(args.output_format)
 
     # Generate the formula
     try:

--- a/cnfformula/csp.py
+++ b/cnfformula/csp.py
@@ -1,0 +1,21 @@
+from cnf import CNF
+from opb import OPB
+
+class CSP(object):
+    """Factory for Constraint Satisfiability Problems
+        
+    Upon instantiation, this class mutates itself into a class that
+    can store and work with constraints of the same type as the output
+    format. The output format is specified globally using `set_format`.
+    """
+
+    _formats = {'dimacs': CNF, 'latex': CNF, 'opb': OPB}
+    _factoryformat = CNF
+
+    def __init__(self):
+        self.__class__ = CSP._factoryformat
+        CSP._factoryformat.__init__(self)
+
+    @classmethod
+    def set_format(cls,output):
+        CSP._factoryformat = CSP._formats[output]

--- a/cnfformula/families/cliquecoloring.py
+++ b/cnfformula/families/cliquecoloring.py
@@ -3,7 +3,7 @@
 """Implementation of the clique-coloring formula 
 """
 
-from cnfformula.cnf import CNF
+from cnfformula.csp import CSP
 
 import cnfformula.cmdline
 import cnfformula.families
@@ -61,7 +61,7 @@ def CliqueColoring(n,k,c):
         "Name of an coloring variable"
         return 'r_{{{0},{1}}}'.format(v,ell)
     
-    formula=CNF()
+    formula=CSP()
     formula.header="There is a graph of {0} vertices with a {1}-clique".format(n,k)+\
         " and a {0}-coloring\n\n".format(c)\
         + formula.header
@@ -81,7 +81,7 @@ def CliqueColoring(n,k,c):
 
     # some vertex is i'th member of clique
     for k in range(1,k+1):
-        for cl in CNF.equal_to_constraint([Q(k,v) for v in range(1,n+1)], 1):
+        for cl in formula.equal_to_constraint([Q(k,v) for v in range(1,n+1)], 1):
             formula.add_clause(cl,strict=True)
 
     # clique members are connected by edges
@@ -95,7 +95,7 @@ def CliqueColoring(n,k,c):
 
     # every vertex v has exactly one colour
     for v in range(1,n+1):
-        for cl in CNF.equal_to_constraint([R(v,ell) for ell in range(1,c+1)], 1):
+        for cl in formula.equal_to_constraint([R(v,ell) for ell in range(1,c+1)], 1):
             formula.add_clause(cl,strict=True)
 
     # neighbours have distinct colours

--- a/cnfformula/families/coloring.py
+++ b/cnfformula/families/coloring.py
@@ -4,7 +4,7 @@
 """
 
 
-from cnfformula.cnf import CNF
+from cnfformula.csp import CSP
 from cnfformula.cmdline import SimpleGraphHelper
 
 from cnfformula.cmdline  import register_cnfgen_subcommand
@@ -38,7 +38,7 @@ def GraphColoringFormula(G,colors,functional=True):
        the CNF encoding of the coloring problem on graph ``G``
 
     """
-    col=CNF()
+    col=CSP()
 
     if isinstance(colors,int) and colors>=0:
         colors = range(1,colors+1)
@@ -114,7 +114,7 @@ def EvenColoringFormula(G):
        Journal on Satisfiability, Boolean Modeling and Computation 2 (2006) 221-228
 
     """
-    F = CNF()
+    F = CSP()
     F.header = "Even coloring formula on graph " + G.name + "\n" + F.header
 
     def var_name(u,v):
@@ -134,8 +134,8 @@ def EvenColoringFormula(G):
 
         edge_vars = [ var_name(u,v) for u in neighbors(G,v) ]
         
-        for cls in CNF.equal_to_constraint(edge_vars,
-                                           len(edge_vars)/2):
+        for cls in F.equal_to_constraint(edge_vars,
+                                         len(edge_vars)/2):
             F.add_clause(cls,strict=True)
 
     return F

--- a/cnfformula/families/counting.py
+++ b/cnfformula/families/counting.py
@@ -3,7 +3,7 @@
 """Implementation of counting/matching formulas
 """
 
-from cnfformula.cnf import CNF
+from cnfformula.csp import CSP
 from cnfformula.cmdline import SimpleGraphHelper
 
 from cnfformula.cmdline  import register_cnfgen_subcommand
@@ -25,7 +25,7 @@ def CountingPrinciple(M,p):
     - `p`  : size of each class
 
     """
-    cnf=CNF()
+    cnf=CSP()
 
     # Describe the formula
     name="Counting Principle: {0} divided in parts of size {1}.".format(M,p)
@@ -45,7 +45,7 @@ def CountingPrinciple(M,p):
 
         edge_vars = [var_name(tpl) for tpl in incidence[el]]
 
-        for cls in CNF.equal_to_constraint(edge_vars,1):
+        for cls in cnf.equal_to_constraint(edge_vars,1):
             cnf.add_clause(cls)
 
     return cnf
@@ -63,7 +63,7 @@ def PerfectMatchingPrinciple(G):
     G : undirected graph
 
     """
-    cnf=CNF()
+    cnf=CSP()
 
     # Describe the formula
     name="Perfect Matching Principle"
@@ -84,7 +84,7 @@ def PerfectMatchingPrinciple(G):
 
         edge_vars = [var_name(u,v) for u in neighbors(G,v)]
 
-        for cls in CNF.equal_to_constraint(edge_vars,1):
+        for cls in cnf.equal_to_constraint(edge_vars,1):
             cnf.add_clause(cls)
 
     return cnf

--- a/cnfformula/families/dominatingset.py
+++ b/cnfformula/families/dominatingset.py
@@ -4,7 +4,7 @@
 """
 
 
-from cnfformula.cnf import CNF
+from cnfformula.csp import CSP
 from cnfformula.cmdline import SimpleGraphHelper
 
 from cnfformula.cmdline  import register_cnfgen_subcommand
@@ -39,7 +39,7 @@ def DominatingSet(G,d, alternative = False):
        the CNF encoding for dominating of size :math:`\leq d` for graph :math:`G`
 
     """
-    F=CNF()
+    F=CSP()
 
     if not isinstance(d,int) or d<1:
         ValueError("Parameter \"d\" is expected to be a positive integer")
@@ -78,7 +78,7 @@ def DominatingSet(G,d, alternative = False):
                 F.add_clause( [ (False,D(u)),(False,D(v)), (False,M(u,i)), (False,M(v,i))    ])
     else:
         for i in range(1,d+1):
-            for c in CNF.less_or_equal_constraint([M(v,i) for v in V],1):
+            for c in F.less_or_equal_constraint([M(v,i) for v in V],1):
                 F.add_clause(c)
                 
     # (Active) Vertices in the sequence are not repeated

--- a/cnfformula/families/graphisomorphism.py
+++ b/cnfformula/families/graphisomorphism.py
@@ -3,7 +3,7 @@
 """Graph isomorphimsm/automorphism formulas
 """
 
-from cnfformula.cnf import CNF
+from cnfformula.csp import CSP
 from cnfformula.cmdline import SimpleGraphHelper
 
 from cnfformula.cmdline  import register_cnfgen_subcommand
@@ -39,7 +39,7 @@ def GraphIsomorphism(G1, G2):
     are isomorphic.
 
     """
-    F = CNF()
+    F = CSP()
     F.header = "Graph Isomorphism problem between graphs " +\
                G1.name + " and " + G2.name + "\n" + F.header
 
@@ -95,7 +95,7 @@ def GraphAutomorphism(G):
     A CNF formula which is satiafiable if and only if graph G has a
     nontrivial automorphism.
     """
-    tmp = CNF()
+    tmp = CSP()
     header = "Graph automorphism formula for graph "+ G.name +"\n"+ tmp.header
     F = GraphIsomorphism(G, G)
     F.header = header

--- a/cnfformula/families/ordering.py
+++ b/cnfformula/families/ordering.py
@@ -3,7 +3,7 @@
 """Implementation of the ordering principle formulas
 """
 
-from cnfformula.cnf import CNF
+from cnfformula.csp import CSP
 from cnfformula.cmdline import SimpleGraphHelper
 
 import cnfformula.cmdline  
@@ -43,7 +43,7 @@ def GraphOrderingPrinciple(graph,total=False,smart=False,plant=False,knuth=0):
     - `plant` : allow last element to be minimum (and could make the formula SAT)
     - `knuth` : Don Knuth variants 2 or 3 of the formula (anything else suppress it)
     """
-    gop = CNF()
+    gop = CSP()
 
     # Describe the formula
     if total or smart:

--- a/cnfformula/families/pebbling.py
+++ b/cnfformula/families/pebbling.py
@@ -6,7 +6,7 @@
 from __future__ import print_function
 
 
-from cnfformula.cnf import CNF
+from cnfformula.csp import CSP
 from cnfformula.graphs import is_dag,enumerate_vertices
 from cnfformula.graphs import has_bipartition,bipartite_sets
 
@@ -50,7 +50,7 @@ def PebblingFormula(digraph):
     if not is_dag(digraph):
         raise ValueError("Pebbling formula is defined only for directed acyclic graphs")
 
-    peb=CNF()
+    peb=CSP()
 
     if hasattr(digraph,'name'):
         peb.header="Pebbling formula of: "+digraph.name+"\n\n"+peb.header
@@ -205,7 +205,7 @@ def StoneFormula(D,nstones):
     if nstones<0:
         raise ValueError("There must be at least one stone.")
 
-    cnf = CNF()
+    cnf = CSP()
 
     if hasattr(D, 'name'):
         cnf.header = "Stone formula of: " + D.name + "\nwith " + str(nstones) + " stones\n" + cnf.header
@@ -319,7 +319,7 @@ def SparseStoneFormula(D,B):
     if len(Left) != D.order():
         raise ValueError("Formula requires the bipartite left side to match #vertices of the DAG.")
      
-    cnf = CNF()
+    cnf = CSP()
     
     if hasattr(D, 'name'):
         cnf.header = "Sparse Stone formula of: " + D.name + "\nwith " + str(nstones) + " stones\n" + cnf.header

--- a/cnfformula/families/pigeonhole.py
+++ b/cnfformula/families/pigeonhole.py
@@ -3,7 +3,7 @@
 """Implementation of the pigeonhole principle formulas
 """
 
-from cnfformula.cnf import CNF
+from cnfformula.csp import CSP
 from cnfformula.cmdline import BipartiteGraphHelper
 from cnfformula.graphs import bipartite_sets
 
@@ -75,7 +75,7 @@ def PigeonholePrinciple(pigeons,holes,functional=False,onto=False):
         else:
             formula_name="Pigeonhole principle"
             
-    php=CNF()
+    php=CSP()
     php.header="{0} formula for {1} pigeons and {2} holes\n".format(formula_name,pigeons,holes)\
         + php.header
 
@@ -142,7 +142,7 @@ def GraphPigeonholePrinciple(graph,functional=False,onto=False):
             formula_name="Graph pigeonhole principle"
 
 
-    gphp=CNF()
+    gphp=CSP()
     gphp.header="{0} formula for graph {1}\n".format(formula_name,graph.name)
 
     Left, Right = bipartite_sets(graph)
@@ -178,7 +178,7 @@ def BinaryPigeonholePrinciple(pigeons,holes):
        number of holes
     """
 
-    bphp=CNF()
+    bphp=CSP()
     bphp.header="Binary Pigeonhole Principle for {0} pigeons and {1} holes\n".format(pigeons,holes)\
                  + bphp.header
     

--- a/cnfformula/families/ramsey.py
+++ b/cnfformula/families/ramsey.py
@@ -3,7 +3,7 @@
 """CNF Formulas for Ramsey-like statements
 """
 
-from cnfformula.cnf import CNF
+from cnfformula.csp import CSP
 
 import cnfformula.cmdline
 import cnfformula.families
@@ -41,7 +41,7 @@ def PythagoreanTriples(N):
            arXiv preprint arXiv:1605.00723, 2016.
     """
 
-    ptn=CNF()
+    ptn=CSP()
 
     ptn.header=dedent("""
 It is possible to bicolor the numbers from
@@ -78,7 +78,7 @@ def RamseyLowerBoundFormula(s,k,N):
     - `N`: vertices
     """
 
-    ram=CNF()
+    ram=CSP()
 
     ram.header=dedent("""\
         CNF encoding of the claim that there is a graph of %d vertices

--- a/cnfformula/families/randomformulas.py
+++ b/cnfformula/families/randomformulas.py
@@ -6,7 +6,7 @@
 import itertools
 import random
 
-from cnfformula.cnf import CNF
+from cnfformula.csp import CSP
 
 import cnfformula.cmdline
 import cnfformula.families
@@ -106,7 +106,7 @@ def RandomKCNF(k, n, m, seed=None, planted_assignments=[]):
     if k>n:
         raise ValueError("Clauses cannot have more {} literals.".format(n))
 
-    F = CNF()
+    F = CSP()
     F.header = "Random {}-CNF over {} variables and {} clauses\n".format(k,n,m) + F.header
 
     indices = xrange(1,n+1)

--- a/cnfformula/families/simple.py
+++ b/cnfformula/families/simple.py
@@ -3,7 +3,7 @@
 """Implementation of simple formulas
 """
 
-from cnfformula.cnf import CNF
+from cnfformula.csp import CSP
 
 import cnfformula.cmdline
 
@@ -35,7 +35,7 @@ class OR(object):
         """
         clause = [ (True,"x_{}".format(i)) for i in range(args.P) ] + \
                  [ (False,"y_{}".format(i)) for i in range(args.N) ]
-        orcnf =  CNF([clause])
+        orcnf =  CSP([clause])
         orcnf.header = "Clause with {} positive and {} negative literals\n\n".format(args.P,args.N) + \
                        orcnf.header
         return orcnf
@@ -68,7 +68,7 @@ class AND(object):
         """
         clauses = [ [(True,"x_{}".format(i))] for i in range(args.P) ] + \
                   [ [(False,"y_{}".format(i))] for i in range(args.N) ]
-        andcnf =  CNF(clauses)
+        andcnf =  CSP(clauses)
         andcnf.header = "Singleton clauses: {} positive and {} negative\n\n""".format(args.P,args.N) +\
                         andcnf.header
         return andcnf
@@ -95,7 +95,7 @@ class EMPTY(object):
         args : ignored 
              command line options
         """
-        return CNF()
+        return CSP()
 
 @cnfformula.cmdline.register_cnfgen_subcommand
 class EMPTY_CLAUSE(object):
@@ -118,5 +118,5 @@ class EMPTY_CLAUSE(object):
         args : ignored 
              command line options
         """
-        return CNF([[]])
+        return CSP([[]])
 

--- a/cnfformula/families/subgraph.py
+++ b/cnfformula/families/subgraph.py
@@ -3,7 +3,7 @@
 """Implementation of formulas that check for subgraphs
 """
 
-from cnfformula.cnf import CNF
+from cnfformula.csp import CSP
 from cnfformula.cmdline import SimpleGraphHelper
 
 import cnfformula.families
@@ -57,7 +57,7 @@ def SubgraphFormula(graph,templates, symmetric=False):
 
     """
 
-    F=CNF()
+    F=CSP()
 
     
     # One of the templates is chosen to be the subgraph
@@ -203,7 +203,7 @@ def BinaryCliqueFormula(G,k):
     a CNF object
 
     """
-    F=CNF()
+    F=CSP()
     F.header="Binary {0}-clique formula\n".format(k) + F.header
     
     clauses_gen=F.binary_mapping(xrange(1,k+1), G.nodes(),

--- a/cnfformula/families/subsetcardinality.py
+++ b/cnfformula/families/subsetcardinality.py
@@ -3,7 +3,7 @@
 """Implementation of subset cardinality formulas
 """
 
-from cnfformula.cnf import CNF
+from cnfformula.csp import CSP
 
 from cnfformula.cmdline import BipartiteGraphHelper
 
@@ -82,7 +82,7 @@ def SubsetCardinalityFormula(B, equalities = False):
     """
     Left, Right = bipartite_sets(B)
             
-    ssc=CNF()
+    ssc=CSP()
     ssc.header="Subset cardinality formula for graph {0}\n".format(B.name)
 
     def var_name(u,v):
@@ -100,20 +100,20 @@ def SubsetCardinalityFormula(B, equalities = False):
         edge_vars = [ var_name(u,v) for v in neighbors(B,u) ]
 
         if equalities:
-            for cls in CNF.exactly_half_ceil(edge_vars):
+            for cls in ssc.exactly_half_ceil(edge_vars):
                 ssc.add_clause(cls,strict=True)
         else:
-            for cls in CNF.loose_majority_constraint(edge_vars):
+            for cls in ssc.loose_majority_constraint(edge_vars):
                 ssc.add_clause(cls,strict=True)
 
     for v in Right:
         edge_vars = [ var_name(u,v) for u in neighbors(B,v) ]
 
         if equalities:
-            for cls in CNF.exactly_half_floor(edge_vars):
+            for cls in ssc.exactly_half_floor(edge_vars):
                 ssc.add_clause(cls,strict=True)
         else:
-            for cls in CNF.loose_minority_constraint(edge_vars):
+            for cls in ssc.loose_minority_constraint(edge_vars):
                 ssc.add_clause(cls,strict=True)
     
     return ssc

--- a/cnfformula/families/tseitin.py
+++ b/cnfformula/families/tseitin.py
@@ -3,7 +3,7 @@
 """Implementation of Tseitin formulas
 """
 
-from cnfformula.cnf import CNF
+from cnfformula.csp import CSP
 
 from cnfformula.cmdline import SimpleGraphHelper
 from cnfformula.graphs import enumerate_vertices,neighbors
@@ -34,7 +34,7 @@ def TseitinFormula(graph,charges=None):
         charges=charges+[0]*(len(V)-len(charges))  # pad with even charges
 
     # init formula
-    tse=CNF()
+    tse=CSP()
     edgename = { }
     
     for (u,v) in sorted(graph.edges(),key=sorted):
@@ -47,7 +47,7 @@ def TseitinFormula(graph,charges=None):
         
         # produce all clauses and save half of them
         names = [ edgename[(u,v)] for u in neighbors(graph,v) ]
-        for cls in CNF.parity_constraint(names,c):
+        for cls in tse.parity_constraint(names,c):
             tse.add_clause(list(cls),strict=True)
 
     return tse

--- a/cnfformula/opb.py
+++ b/cnfformula/opb.py
@@ -1,0 +1,43 @@
+from __future__ import print_function
+
+from cnf import CNF
+
+class OPB(CNF):
+    def __init__(self):
+        self._constraints = []
+        self.add_clause_unsafe = self.add_constraint
+        self.add_clause = self.add_constraint
+        CNF.__init__(self)
+
+    def dimacs(self, export_header=False, extra_text=None):
+        from cStringIO import StringIO
+        output = StringIO()
+        output.write("* #variable= {} #constraint= {}\n".format(
+            len(self._index2name),len(self._constraints)))
+        for c in self._constraints:
+            freeterm = c[-1]
+            for term in c[:-1]:
+                coefficient = term[0]
+                literal = "x" + str(self._name2index[term[2]]+1)
+                if not term[1] :
+                    coefficient *= -1
+                    freeterm += coefficient
+                    # literal = "~" + literal
+                output.write("{} {} ".format(coefficient,literal))
+            output.write(">= {} ;\n".format(freeterm))
+
+        return output.getvalue()
+        
+    def add_constraint(self, constraint, strict=False):
+        freeterm = constraint[-1]
+        if isinstance(freeterm,tuple):
+            # Got a disjunction
+            constraint = [(1,)+lit for lit in constraint] + [1]
+        self._constraints.append(constraint)
+
+    @classmethod
+    def _inequality_constraint_builder(cls, variables, k, greater=False):
+        if greater:
+            yield [(1,True,var) for var in variables] + [k+1]
+        else:
+            yield [(-1,True,var) for var in variables] + [-k+1]

--- a/cnfformula/opb.py
+++ b/cnfformula/opb.py
@@ -7,18 +7,18 @@ class OPB(CNF):
         self._constraints = []
         self.add_clause_unsafe = self.add_constraint
         self.add_clause = self.add_constraint
-        CNF.__init__(self)
-
+        super(OPB,self).__init__()
+        
     def dimacs(self, export_header=False, extra_text=None):
         from cStringIO import StringIO
         output = StringIO()
         output.write("* #variable= {} #constraint= {}\n".format(
-            len(self._index2name),len(self._constraints)))
+            len(self._name2index),len(self._constraints)))
         for c in self._constraints:
             freeterm = c[-1]
             for term in c[:-1]:
                 coefficient = term[0]
-                literal = "x" + str(self._name2index[term[2]]+1)
+                literal = "x" + str(self._name2index[term[2]])
                 if not term[1] :
                     coefficient *= -1
                     freeterm += coefficient

--- a/cnfformula/opb.py
+++ b/cnfformula/opb.py
@@ -12,11 +12,22 @@ class OPB(CNF):
     def dimacs(self, export_header=False, extra_text=None):
         from cStringIO import StringIO
         output = StringIO()
+
         output.write("* #variable= {} #constraint= {}\n".format(
             len(self._name2index),len(self._constraints)))
+
+        if export_header:
+            for line in self.header.split("\n")[:-1]:
+                output.write(("* "+line).rstrip()+"\n")
+
+            if extra_text is not None:
+                for line in extra_text.split("\n"):
+                    output.write(("* "+line).rstrip()+"\n")
+
         for c in self._constraints:
             freeterm = c[-1]
-            for term in c[:-1]:
+            relation = c[-2]
+            for term in c[:-2]:
                 coefficient = term[0]
                 literal = "x" + str(self._name2index[term[2]])
                 if not term[1] :
@@ -24,7 +35,7 @@ class OPB(CNF):
                     freeterm += coefficient
                     # literal = "~" + literal
                 output.write("{} {} ".format(coefficient,literal))
-            output.write(">= {} ;\n".format(freeterm))
+            output.write("{} {} ;\n".format(relation,freeterm))
 
         return output.getvalue()
         
@@ -32,12 +43,19 @@ class OPB(CNF):
         freeterm = constraint[-1]
         if isinstance(freeterm,tuple):
             # Got a disjunction
-            constraint = [(1,)+lit for lit in constraint] + [1]
+            constraint = [(1,)+lit for lit in constraint] + [">="] + [1]
+        relation = constraint[-2]
+        if relation not in (">=","="):
+            raise ValueError("Unsupported constraint type")
         self._constraints.append(constraint)
 
     @classmethod
     def _inequality_constraint_builder(cls, variables, k, greater=False):
         if greater:
-            yield [(1,True,var) for var in variables] + [k+1]
+            yield [(1,True,var) for var in variables] + [">="] + [k+1]
         else:
-            yield [(-1,True,var) for var in variables] + [-k+1]
+            yield [(-1,True,var) for var in variables] + [">="] + [-k+1]
+
+    @classmethod
+    def equal_to_constraint(cls, variables, value):
+        yield [(1,True,var) for var in variables] + ["="] + [value]


### PR DESCRIPTION
I finally got to clean up my OPB branch and prepare it for merging. I believe this is similar to what you had in mind in your email from 24 Nov 2016: an extra value `opb` as output format, plus a base object `CSP` that can be either a `CNF` or an `OBP` (or maybe you want to rename that to `ZOIP`).

I assume that eventually a big part of `CNF` will move to `CSP`, but for now I am trying to change the existing code as little as possible (and indeed your previous refactoring made this much easier).