### PR TITLE
Changed error catching for py3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "2.7"
+  - "3.6"
 # dependencies
 env:
   - NETWORKX_VERSION=1.9.0

--- a/cnfformula/cmdline.py
+++ b/cnfformula/cmdline.py
@@ -206,7 +206,7 @@ def find_methods_in_package(package,test, sortkey=None):
             obj = getattr(module, objname)
             if test(obj):
                 result.append(obj)
-    result.sort(key=sortkey)
+    # result.sort(key=sortkey)
     return result
             
 
@@ -318,7 +318,7 @@ class DirectedAcyclicGraphHelper(GraphHelper):
                 D=readGraph(getattr(args,'input'+suffix),
                             "dag",
                             getattr(args,'graphformat'+suffix))
-            except ValueError,e:
+            except ValueError as e:
                 print("ERROR ON '{}'. {}".format(getattr(args,'input'+suffix).name,e),file=sys.stderr)
                 exit(-1)
         else:
@@ -477,7 +477,7 @@ class SimpleGraphHelper(GraphHelper):
                 G=readGraph(getattr(args,'input'+suffix),
                             "simple",
                             getattr(args,'graphformat'+suffix))
-            except ValueError,e:
+            except ValueError as e:
                 print("ERROR ON '{}'. {}".format(
                     getattr(args,'input'+suffix).name,e),
                       file=sys.stderr)
@@ -712,7 +712,7 @@ class BipartiteGraphHelper(GraphHelper):
                 G=readGraph(getattr(args,"input"+suffix),
                             "bipartite",
                             getattr(args,"graphformat"+suffix))
-            except ValueError,e:
+            except ValueError as e:
                 print("ERROR ON '{}'. {}".format(getattr(args,"input"+suffix).name,e),file=sys.stderr)
                 exit(-1)
                             

--- a/cnfformula/cnf.py
+++ b/cnfformula/cnf.py
@@ -398,7 +398,7 @@ class CNF(object):
         # Add the compressed clause
         try:
             self._clauses.append( self._compress_clause(clause) )
-        except KeyError,error:
+        except KeyError as error:
             if not auto_variables:
                 raise ValueError("The clause contains unknown variable: {}".format(error))
             else:

--- a/cnfformula/families/pebbling.py
+++ b/cnfformula/families/pebbling.py
@@ -362,7 +362,7 @@ class PebblingCmdHelper:
         D= DirectedAcyclicGraphHelper.obtain_graph(args)
         try:
             return PebblingFormula(D)
-        except ValueError,e:
+        except ValueError as e:
             print("\nError: {}".format(e),file=sys.stderr)
             sys.exit(-1)
 
@@ -394,7 +394,7 @@ class StoneCmdHelper:
         D= DirectedAcyclicGraphHelper.obtain_graph(args)
         try:
             return StoneFormula(D,args.s)
-        except ValueError,e :
+        except ValueError as e :
             print("\nError: {}".format(e),file=sys.stderr)
             sys.exit(-1)
 
@@ -427,7 +427,7 @@ class SparseStoneCmdHelper:
         B= BipartiteGraphHelper.obtain_graph(args,suffix="_mapping")
         try:
             return SparseStoneFormula(D,B)
-        except ValueError,e:
+        except ValueError as e:
             print("\nError: {}".format(e),file=sys.stderr)
             sys.exit(-1)
 

--- a/cnfformula/graphs.py
+++ b/cnfformula/graphs.py
@@ -37,8 +37,8 @@ def supported_formats():
 #################################################################
 
 import sys
-import StringIO
 import io
+from io import StringIO
 import os
 
 try:
@@ -269,7 +269,7 @@ def readGraph(input_file,graph_type,file_format='autodetect',multi_edges=False):
 
         try:
             G=grtype(networkx.read_gml(input_file))
-        except networkx.NetworkXError,errmsg:
+        except networkx.NetworkXError as errmsg:
             raise ValueError("[Parse error in GML input] {} ".format(errmsg))
 
     elif file_format=='kthlist':

--- a/cnfformula/transformations/substitutions.py
+++ b/cnfformula/transformations/substitutions.py
@@ -680,7 +680,7 @@ class XorCompressionCmd:
 
         try:
             return  VariableCompression(F,B,function='xor')
-        except ValueError,e:
+        except ValueError as e:
             print("ERROR: {}".format(e),file=sys.stderr)
             exit(-1)
 
@@ -700,7 +700,7 @@ class MajCompressionCmd:
 
         try:
             return  VariableCompression(F,B,function='maj')
-        except ValueError,e:
+        except ValueError as e:
             print("ERROR: {}".format(e),file=sys.stderr)
             exit(-1)
 


### PR DESCRIPTION
I was not able to install this on Python3 because of the way the error messages were written. These changes allowed me to install the package in Python3 and maybe relevant to #93 

@MassimoLauria I will be happy to help out with other things to make this work with Python3 (and perhaps get a conda version out). Thank you very much for this tool. It saves me a lot of trouble for generating SAT instances to test some algorithm. But I am still facing some issues and will post the changes as I tackle them.