### PR TITLE
Fix file types in cnfshuffle parser

### DIFF
--- a/cnfformula/utils/cnfshuffle.py
+++ b/cnfformula/utils/cnfshuffle.py
@@ -41,7 +41,7 @@ def command_line_utility(argv=sys.argv):
     """ % (progname))
 
     parser.add_argument('--output','-o',
-                        type=argparse.FileType('wb',0),
+                        type=argparse.FileType('w'),
                         metavar="<output>",
                         default='-',
                         help="""Output file. The formula is saved
@@ -60,7 +60,7 @@ def command_line_utility(argv=sys.argv):
                         be fine.  (default: current time)
                         """)
     parser.add_argument('--input','-i',
-                        type=argparse.FileType('r',0),
+                        type=argparse.FileType('r'),
                         metavar="<input>",
                         default='-',
                         help="""Input file. A formula in dimacs format. Setting '<input>' to '-' is


### PR DESCRIPTION
`cnfshuffle` currently does not work with named input/output files. For input files, a value of `0` for buffering is only allowed for binary files, so I suggest to use the default line-based buffering. For output files, the code assumes the file is a string buffer, not a binary buffer, so I suggest to use mode `w` instead of `wb`. As a consequence, I am also reverting to default buffering.