### PR TITLE
Replace dead satlib.org links with working counterparts at ubc.ca

### DIFF
--- a/cnfformula/cnf.py
+++ b/cnfformula/cnf.py
@@ -524,7 +524,7 @@ class CNF(object):
 
         References
         ----------
-        .. [1] http://www.satlib.org/Benchmarks/SAT/satformat.ps
+        .. [1] http://www.cs.ubc.ca/~hoos/SATLIB/Benchmarks/SAT/satformat.ps
 
         """
         from io import StringIO

--- a/docs/buildcnf.rst
+++ b/docs/buildcnf.rst
@@ -126,5 +126,5 @@ argument   ``full_document``    to   ``True``    in   the    call   to
    
 Reference
 ---------
-.. [1] http://www.satlib.org/Benchmarks/SAT/satformat.ps
+.. [1] http://www.cs.ubc.ca/~hoos/SATLIB/Benchmarks/SAT/satformat.ps
 .. [2] http://www.latex-project.org/ 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -117,7 +117,7 @@ formula generator type ``cnfgen <generator_name> --help``.
 
 Reference
 ---------
-.. [1] http://www.satlib.org/Benchmarks/SAT/satformat.ps
+.. [1] http://www.cs.ubc.ca/~hoos/SATLIB/Benchmarks/SAT/satformat.ps
 .. [2] http://www.latex-project.org/ 
 .. [3] http://en.wikipedia.org/wiki/Proof_complexity
 


### PR DESCRIPTION
satlib.org now hosts NSFW content, better point these links somewhere else.