### PR TITLE
Support generating clique formulas without symmetry breaking

### DIFF
--- a/cnfgen/clihelpers/graph_helpers.py
+++ b/cnfgen/clihelpers/graph_helpers.py
@@ -210,6 +210,10 @@ class KCliqueCmdHelper(FormulaHelper):
             'G',
             help='a simple undirected graph (see \'cnfgen --help-graph\')',
             action=ObtainSimpleGraph)
+        parser.add_argument('--no-monotone',
+                            action='store_false',
+                            dest='monotone',
+                            help="Do not enforce the solution to be in increasing order")
 
     @staticmethod
     def build_cnf(args):
@@ -218,7 +222,7 @@ class KCliqueCmdHelper(FormulaHelper):
         Arguments:
         - `args`: command line options
         """
-        return CliqueFormula(args.G, args.k)
+        return CliqueFormula(args.G, args.k, args.monotone)
 
 
 class BinaryKCliqueCmdHelper(FormulaHelper):

--- a/cnfgen/clihelpers/graph_helpers.py
+++ b/cnfgen/clihelpers/graph_helpers.py
@@ -210,10 +210,10 @@ class KCliqueCmdHelper(FormulaHelper):
             'G',
             help='a simple undirected graph (see \'cnfgen --help-graph\')',
             action=ObtainSimpleGraph)
-        parser.add_argument('--no-monotone',
+        parser.add_argument('--no-symmetry-breaking',
                             action='store_false',
-                            dest='monotone',
-                            help="Do not enforce the solution to be in increasing order")
+                            dest='symmetrybreaking',
+                            help="Do not break symmetries by enforcing the solution to be in increasing order")
 
     @staticmethod
     def build_cnf(args):
@@ -222,7 +222,7 @@ class KCliqueCmdHelper(FormulaHelper):
         Arguments:
         - `args`: command line options
         """
-        return CliqueFormula(args.G, args.k, args.monotone)
+        return CliqueFormula(args.G, args.k, args.symmetrybreaking)
 
 
 class BinaryKCliqueCmdHelper(FormulaHelper):

--- a/cnfgen/families/subgraph.py
+++ b/cnfgen/families/subgraph.py
@@ -152,7 +152,7 @@ def SubgraphFormula(graph, templates, symmetric=False):
     return F
 
 
-def CliqueFormula(G, k, monotone=True):
+def CliqueFormula(G, k, symmetric=True):
     """Test whether a graph has a k-clique.
 
     Given a graph :math:`G` and a non negative value :math:`k`, the
@@ -164,15 +164,15 @@ def CliqueFormula(G, k, monotone=True):
         a simple graph
     k : a non negative integer
         clique size
-    monotone: bool
-        ordered mapping
+    symmetric: bool
+        symmetry breaking
 
     Returns
     -------
     a CNF object
 
     """
-    F = SubgraphFormula(G, [complete_graph(k)], symmetric=monotone)
+    F = SubgraphFormula(G, [complete_graph(k)], symmetric=symmetric)
     description = "{} does not contain any {}-clique.".format(G.name, k)
     F.header['description'] = description
     return F

--- a/cnfgen/families/subgraph.py
+++ b/cnfgen/families/subgraph.py
@@ -152,7 +152,7 @@ def SubgraphFormula(graph, templates, symmetric=False):
     return F
 
 
-def CliqueFormula(G, k):
+def CliqueFormula(G, k, monotone=True):
     """Test whether a graph has a k-clique.
 
     Given a graph :math:`G` and a non negative value :math:`k`, the
@@ -164,13 +164,15 @@ def CliqueFormula(G, k):
         a simple graph
     k : a non negative integer
         clique size
+    monotone: bool
+        ordered mapping
 
     Returns
     -------
     a CNF object
 
     """
-    F = SubgraphFormula(G, [complete_graph(k)], symmetric=True)
+    F = SubgraphFormula(G, [complete_graph(k)], symmetric=monotone)
     description = "{} does not contain any {}-clique.".format(G.name, k)
     F.header['description'] = description
     return F


### PR DESCRIPTION
Clique formulas have symmetry breaking by default, but the encoding without symmetry breaking is also fairly common. This adds an option to produce such an encoding.