### PR TITLE
Add option to export variable names as comments in DIMACS output

### DIFF
--- a/cnfgen/clitools/cnfgen.py
+++ b/cnfgen/clitools/cnfgen.py
@@ -249,6 +249,9 @@ def setup_command_line_parsers(progname, fhelpers, thelpers):
                    dest='verbose',
                    help="""Output just the formula with no header.""")
 
+    parser.add_argument('--varnames', action='store_true', default=False,
+                        help="Output map from variable indices to names.")
+
     # setup each formula command parser
     subparsers = parser.add_subparsers(prog=progname,
                                        title="Available formula types",
@@ -460,7 +463,8 @@ def cli(argv=sys.argv, mode='output'):
 
         elif args.output_format == 'dimacs':
 
-            output = cnf.dimacs(export_header=args.verbose)
+            output = cnf.dimacs(export_header=args.verbose,
+                                export_varnames=args.varnames)
 
         else:
             raise InternalBug("Unknown output format")

--- a/cnfgen/cnf.py
+++ b/cnfgen/cnf.py
@@ -461,7 +461,8 @@ class CNF(object):
         """
         return self.__iter__()
 
-    def dimacs(self, export_header=True, extra_text=None):
+    def dimacs(self, export_header=True, extra_text=None,
+               export_varnames=False):
         """Produce the dimacs encoding of the formula
 
         The formula is rendered in the DIMACS format for CNF formulas,
@@ -478,6 +479,10 @@ class CNF(object):
 
         extra_text : str, optional
             Additional text attached to the header
+
+        export_varnames : bool, optional
+            determines whether a map from variable indices to variable
+            names should be appended to the header.
 
         Returns
         -------
@@ -508,13 +513,15 @@ class CNF(object):
         """
         from io import StringIO
         output = StringIO()
-        self._dimacs_dump_clauses(output, export_header, extra_text)
+        self._dimacs_dump_clauses(output, export_header, extra_text,
+                                  export_varnames)
         return output.getvalue()
 
     def _dimacs_dump_clauses(self,
                              output,
                              export_header=True,
-                             extra_text=None):
+                             extra_text=None,
+                             export_varnames=False):
         """Dump the dimacs encoding of the formula to the file-like output
 
         This is for internal use only. It produces the dimacs output
@@ -540,6 +547,10 @@ class CNF(object):
                 ascii_extra = ascii_extra.decode('ascii')
                 for line in ascii_extra.split("\n"):
                     output.write(("c " + line).rstrip() + "\n")
+
+        if export_varnames:
+            for index,name in enumerate(self._index2name[1:]):
+                output.write("c varname {} {}\n".format(index+1,name))
 
         # Formula specification
         output.write("p cnf {0} {1}".format(n, m))


### PR DESCRIPTION
It is convenient for humans to work with CNF formulas to have the map between DIMACS literals and variable names handy, preferably in a form that is also machine-readable. Since I do not know of any standard way to write this in a DIMACS file, I am proposing the following format, which would be part of the header:
```
c varname <dimacs> <name>
```

This patch adds support to (optionally) output variable names using this format.