### PR TITLE
Make from_dimacs_file actually return something (Bugfix)

### DIFF
--- a/cnfgen/utils/parsedimacs.py
+++ b/cnfgen/utils/parsedimacs.py
@@ -172,8 +172,7 @@ def from_dimacs_file(cnfclass, fileorname=None):
         name = '<stdin>'
     elif isinstance(fileorname, str):
         with open(fileorname, 'r', encoding='utf-8') as filehandle:
-            from_dimacs_file(cnfclass, filehandle)
-            return
+            return from_dimacs_file(cnfclass, filehandle)
     else:
         inputfile = fileorname
         try:


### PR DESCRIPTION
Currently, `from_dimacs_file` doesn't return anything if you call it with a filename as str. This should fix the bug.