### PR TITLE
Do not display a warning when shuffling a file passed through -i

### DIFF
--- a/cnfgen/clitools/cnfshuffle.py
+++ b/cnfgen/clitools/cnfshuffle.py
@@ -117,8 +117,9 @@ def cli(argv=sys.argv, mode='output'):
              Alternatively you can feed a formula to <stdin>
              with piping or using '-i' command line argument."""
 
-    with msg_prefix("c INPUT: "):
-        interactive_msg(msg, filltext=70)
+    if args.input == sys.stdin:
+        with msg_prefix("c INPUT: "):
+            interactive_msg(msg, filltext=70)
     F = CNF.from_file(args.input)
 
     # Default permutation


### PR DESCRIPTION
Currently calling `cnfshuffle -i file.cnf` prints a warning saying that it is waiting for a DIMACS file on stdin, even though it received the input correctly and it is working on it. This causes confusion on large inputs. This patch disables that warning when the input comes from a file, while keeping it when reading from stdin.